### PR TITLE
fix: handle client-side route refresh error on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This pull request resolves the issue where refreshing client-side routes such as /dashboard, /about, etc., on the deployed Vercel site resulted in a 404 NOT_FOUND error.

> Fixes #112 

## 🐞 Why this Problem occurs:
In production, Vercel tries to fetch a physical file at the refreshed URL (e.g., /dashboard), which doesn't exist in a Single Page Application (SPA). Since routing is handled client-side by React Router, these routes should fall back to index.html.

## 🔍 Type of Change

- [x] Bug fix 🐞
- [ ] New feature ✨
- [ ] Documentation update 📝
- [ ] Refactoring or code improvement ♻️
- [ ] Other (please describe):

## 🙋 Your Details

- **Name**: Lourdu Radjou
- **Email ID**: rajlourdu15@gmail.com

## 🧪 How Has This Been Tested?
I deployed the fix on Vercel and verified that it works as expected. A demo video has been attached to showcase the fix in action.

## 📸 Screenshots (if applicable)

https://github.com/user-attachments/assets/55f2d816-c22b-438c-868a-3dde3de6b977


| Before | After |
|--------|-------|
|    Website crashes when reload happens   |    Now reload happens smoothly   |

## ✅ Checklist

- [x] I have read the contributing guidelines.
- [x] I have followed the code style and linting rules.
- [x] I have added tests or explained why not.
- [ ] I have updated documentation (if needed).
- [x] My changes do not introduce any known security issues or vulnerabilities.

---
