### PR TITLE
Feature: Add Income History Page with synced data and dashboard-style UI(#148)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { CurrencyProvider } from "./components/CurrencyContext";
 import AboutPage from './components/AboutPage';
 import ContactPage from './components/ContactPage';
 import GoalsPage from './components/GoalsPage';
+import IncomeHistoryPage from './components/IncomeHistoryPage';
 
 export default function App() {
 
@@ -21,6 +22,7 @@ export default function App() {
             <Route path="/about" element={<AboutPage />} />
             <Route path="/contact" element={<ContactPage />} />
             <Route path="/goals" element={<GoalsPage />} />
+            <Route path="/income-history" element={<IncomeHistoryPage />} />
           </Routes>
         </Router>
       </CurrencyProvider>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -223,25 +223,32 @@ export default function Dashboard() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
             {/* Income Card */}
-            <div
-              className={`relative p-6 rounded-2xl transition-all duration-500 cursor-pointer transform hover:scale-105 hover:-translate-y-2 ${hoveredCard === "income" ? "shadow-2xl shadow-green-200" : "shadow-lg"
+            <Link to="/income-history">
+              <div
+                className={`relative p-6 rounded-2xl transition-all duration-500 cursor-pointer transform hover:scale-105 hover:-translate-y-2 ${
+                  hoveredCard === "income" ? "shadow-2xl shadow-green-200" : "shadow-lg"
                 } ${isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"}`}
-              style={{
-                background: "linear-gradient(135deg, #10b981 0%, #059669 100%)",
-                animationDelay: "0.2s",
-              }}
-              onMouseEnter={() => setHoveredCard("income")}
-              onMouseLeave={() => setHoveredCard(null)}>
-              <div className="absolute top-4 right-4">
-                <TrendingUp className="w-8 h-8 text-white/80" />
+                style={{
+                  background: "linear-gradient(135deg, #10b981 0%, #059669 100%)",
+                  animationDelay: "0.2s",
+                }}
+                onMouseEnter={() => setHoveredCard("income")}
+                onMouseLeave={() => setHoveredCard(null)}
+              >
+                <div className="absolute top-4 right-4">
+                  <TrendingUp className="w-8 h-8 text-white/80" />
+                </div>
+                <div className="text-white/80 text-sm font-medium mb-2">Total Income</div>
+                <div className="text-3xl font-black text-white mb-1">
+                  {formatCurrency(animatedValues.income)}
+                </div>
+                <div className="text-white/60 text-xs">+12% from last month</div>
+                <div className="absolute bottom-0 left-0 right-0 h-1 bg-white/20 rounded-full">
+                  <div className="h-full bg-white/40 rounded-full w-3/4 animate-[expandWidth_2s_ease-out_1s]"></div>
+                </div>
               </div>
-              <div className="text-white/80 text-sm font-medium mb-2">Total Income</div>
-              <div className="text-3xl font-black text-white mb-1">{formatCurrency(animatedValues.income)}</div>
-              <div className="text-white/60 text-xs">+12% from last month</div>
-              <div className="absolute bottom-0 left-0 right-0 h-1 bg-white/20 rounded-full">
-                <div className="h-full bg-white/40 rounded-full w-3/4 animate-[expandWidth_2s_ease-out_1s]"></div>
-              </div>
-            </div>
+            </Link>
+
 
             {/* Expense Card */}
             <div

--- a/src/components/IncomeHistoryPage.jsx
+++ b/src/components/IncomeHistoryPage.jsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from "react";
+import { useTransactions } from "./TransactionContext";
+import Footer from "./Footer";
+import { ArrowLeft, Calendar, Tag, Trash2, FileEdit } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+export default function IncomeHistoryPage() {
+  const { transactions, deleteTransaction } = useTransactions();
+  const navigate = useNavigate();
+  const [isVisible, setIsVisible] = useState(false);
+  const [darkMode, setDarkMode] = useState(document.documentElement.classList.contains("dark"));
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsVisible(true), 10);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const incomeTransactions = transactions.filter(
+    (txn) => txn.type.toLowerCase() === "income"
+  );
+
+  const maxIncome = Math.max(...incomeTransactions.map(txn => txn.amount || 0), 1); // avoid divide by zero
+
+  const formatDate = (dateStr) => {
+    if (!dateStr) return "";
+    const [day, month, year] = dateStr.split("/");
+    const date = new Date(`${year}-${month}-${day}`);
+    return isNaN(date.getTime()) ? dateStr : date.toLocaleDateString("en-GB", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  };
+
+  return (
+    <div className={`min-h-screen flex flex-col transition-colors duration-300 ${
+      darkMode
+        ? "bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 text-gray-100"
+        : "bg-gradient-to-br from-slate-50 via-blue-50 to-purple-50 text-gray-900"
+    }`}>
+      <main className="flex-1 w-full p-6">
+        <div className="max-w-6xl mx-auto">
+          {/* Header */}
+          <div className={`flex items-center gap-2 mb-6 transition-all duration-700 ${
+            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'
+          }`}>
+            <button
+              onClick={() => navigate("/dashboard")}
+              className="p-2 rounded-full transition-all duration-200 hover:bg-gray-100 dark:hover:bg-gray-800"
+              title="Back to Dashboard"
+            >
+              <ArrowLeft className="w-5 h-5 text-blue-600 dark:text-gray-300" />
+            </button>
+            <h1 className="text-4xl font-black bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+              Income History
+            </h1>
+          </div>
+
+          {/* Income List */}
+          <div className={`transition-opacity duration-700 ${isVisible ? "opacity-100" : "opacity-0"}`}>
+            {incomeTransactions.length > 0 ? (
+              <div className="space-y-4">
+                {incomeTransactions.map((txn) => {
+                  const percentage = Math.round((txn.amount / maxIncome) * 100);
+                  return (
+                    <div
+                      key={txn.id}
+                      className={`rounded-3xl shadow-sm px-4 py-3 border transition-all duration-300 ${
+                        darkMode
+                          ? "bg-gray-800 border-gray-700"
+                          : "bg-white border-gray-200"
+                      }`}
+                    >
+                      <div className="flex justify-between items-center gap-3">
+                        {/* Icon */}
+                        <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gray-200 dark:bg-gray-600">
+                          <FileEdit className="w-6 h-6 text-white" />
+                        </div>
+
+                        {/* Tags, Date, Title */}
+                        <div className="flex-1 ml-2">
+                          <div className="flex items-center gap-3 text-sm text-gray-600 dark:text-gray-300 font-medium mb-1">
+                            <Tag className="w-4 h-4" />
+                            {txn.category || "Others"}
+                            <Calendar className="w-4 h-4 ml-4" />
+                            {formatDate(txn.date)}
+                          </div>
+                          <div className="text-sm text-gray-500 dark:text-gray-400">
+                            {txn.title || "--"}
+                          </div>
+                        </div>
+
+                        {/* Amount + Delete */}
+                        <div className="flex items-center gap-4">
+                          <div className="text-green-500 font-bold text-lg whitespace-nowrap">
+                            +₹{txn.amount.toLocaleString()}
+                          </div>
+                          <button
+                            onClick={() => deleteTransaction(txn.id)}
+                            className="text-gray-400 hover:text-red-500 transition-colors"
+                            title="Delete"
+                          >
+                            <Trash2 className="w-5 h-5" />
+                          </button>
+                        </div>
+                      </div>
+
+                      {/* Relative progress bar */}
+                      <div className="h-1 mt-3 rounded-full bg-gray-200 dark:bg-gray-700">
+                        <div
+                          className="h-1 rounded-full bg-green-500 transition-all duration-500"
+                          style={{ width: `${percentage}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="text-center text-gray-500 dark:text-gray-400 mt-12 text-lg">
+                No income transactions found.
+              </div>
+            )}
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION

# 🚀 Pull Request

## 📋 Description

This PR adds a new **Income History Page** to the application.
It allows users to view only their **income-type transactions** in a clean and dashboard-consistent UI. The layout, animations, icons, and card design follow the existing dashboard style for visual uniformity. Transactions are synced from the global `TransactionContext` and displayed with relevant metadata and styling.

> Fixes #148

## 🔍 Type of Change

- [ ] Bug fix 🐞
- [  ] New feature ✨
- [ ] Documentation update 📝
- [  ] Refactoring or code improvement ♻️
- [ ] Other (please describe):

## 🙋 Your Details

- **Name**: Jayanti Goyal
- **Email ID**: jayantigoyal1911@gmail.com

## 🧪 How Has This Been Tested?

- Manually verified in development environment (`npm run dev`)
- Confirmed:
  - Income transactions display correctly
  - Styling and animations match the dashboard
  - Back button and delete functionality work
  - No `Invalid Date` error
  - Responsive layout on all screen sizes

## 📸 Screenshots (if applicable)
<img width="2817" height="1432" alt="{84354500-9C7A-415E-9527-CD38C3460960}" src="https://github.com/user-attachments/assets/daf54ecc-697a-43a7-9445-6e44fa7d0887" />


## ✅ Checklist

- [  ] I have read the contributing guidelines.
- [  ] I have followed the code style and linting rules.
- [ ] I have added tests or explained why not.
- [ ] I have updated documentation (if needed).
- [  ] My changes do not introduce any known security issues or vulnerabilities.

---
